### PR TITLE
obsidian: set res folder to root of vault

### DIFF
--- a/.obsidian/app.json
+++ b/.obsidian/app.json
@@ -5,5 +5,5 @@
   "newLinkFormat": "relative",
   "newFileLocation": "current",
   "showUnsupportedFiles": true,
-  "attachmentFolderPath": "./res"
+  "attachmentFolderPath": "res"
 }


### PR DESCRIPTION
Tell Obsidian to use the res folder in the root of the vault for pasted content, otherwise, an image pasted into a blog post will be put in posts/res/